### PR TITLE
Refactor and improve client parser

### DIFF
--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -8,59 +8,79 @@ var BODY_TAG_NAME = 'body';
 var HEAD_TAG_NAME = 'head';
 
 /**
- * DOMParser.
+ * DOMParser (performance: slow).
  *
  * https://developer.mozilla.org/docs/Web/API/DOMParser#Parsing_an_SVG_or_HTML_document
  */
-var parse;
+var parseFromString;
 if (typeof DOMParser === 'function') {
-    var parser = new DOMParser();
+    var domParser = new DOMParser();
     var MIME_TYPE = 'text/' + HTML_TAG_NAME;
 
     /**
      * Creates an HTML document using `DOMParser.parseFromString`.
      *
-     * @param  {String} html - The HTML string.
+     * @param  {String} html      - The HTML string.
+     * @param  {String} [tagName] - The tag to wrap the HTML.
      * @return {HTMLDocument}
      */
-    parse = function parseFromString(html) {
-        return parser.parseFromString(html, MIME_TYPE);
+    parseFromString = function domStringParser(html, tagName) {
+        if (tagName) {
+            html = ['<', tagName, '>', html, '</', tagName, '>'].join('');
+        }
+        return domParser.parseFromString(html, MIME_TYPE);
     };
+}
 
 /**
- * DOMImplementation.
+ * DOMImplementation (performance: fair).
  *
  * https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument
  */
-} else if (typeof document.implementation === 'object') {
+var parseFromDocument;
+if (typeof document.implementation === 'object') {
     var doc = document.implementation.createHTMLDocument();
 
     /**
      * Use HTML document created by `document.implementation.createHTMLDocument`.
      *
-     * @param  {String} html - The HTML string.
+     * @param  {String} html      - The HTML string.
+     * @param  {String} [tagName] - The element to render the HTML.
      * @return {HTMLDocument}
      */
-    parse = function createHTMLDocument(html) {
-        doc.documentElement.innerHTML = html;
+    parseFromDocument = function createHTMLDocument(html, tagName) {
+        if (tagName) {
+            doc.documentElement.getElementsByTagName(tagName)[0].innerHTML = html;
+        } else {
+            doc.documentElement.innerHTML = html;
+        }
         return doc;
     };
+}
 
 /**
- * Template.
+ * Template (performance: fast).
  *
  * https://developer.mozilla.org/docs/Web/HTML/Element/template
  */
-} else {
-    var template = document.createElement('template');
+var parseFromTemplate;
+var template = document.createElement('template');
+if (template.content) {
 
-    if (template.content) {
-        parse = function parseTemplate(html) {
-            template.innerHTML = html;
-            return template.content.childNodes;
-        };
-    }
+    /**
+     * Uses a template element (content fragment) to parse HTML.
+     *
+     * @param  {String} html - The HTML string.
+     * @return {NodeList}
+     */
+    parseFromTemplate = function templateParser(html) {
+        template.innerHTML = html;
+        return template.content.childNodes;
+    };
 }
+
+/** Fallback document parser. */
+var parseWithFallback = parseFromDocument || parseFromString;
 
 /**
  * Parses HTML string to DOM nodes.
@@ -70,22 +90,32 @@ if (typeof DOMParser === 'function') {
  * @return {NodeList|Array}
  */
 module.exports = function domparser(html, tagName) {
-    var output = parse(html);
-    if (output instanceof NodeList) return output;
+    switch (tagName) {
+        case HTML_TAG_NAME:
+            if (parseFromString) {
+                return parseFromString(html).getElementsByTagName(HTML_TAG_NAME);
+            }
+            break;
 
-    if (output instanceof HTMLDocument) {
-        // text
-        if (!tagName) {
-            return output.getElementsByTagName(BODY_TAG_NAME)[0].childNodes;
-        }
+        case HEAD_TAG_NAME:
+            if (parseWithFallback) {
+                return parseWithFallback(html).getElementsByTagName(HEAD_TAG_NAME);
+            }
+            break;
 
-        // high-level tags
-        if ([HTML_TAG_NAME, HEAD_TAG_NAME, BODY_TAG_NAME].indexOf(tagName) !== -1) {
-            return output.getElementsByTagName(tagName);
-        }
+        case BODY_TAG_NAME:
+            if (parseWithFallback) {
+                return parseWithFallback(html).getElementsByTagName(BODY_TAG_NAME);
+            }
+            break;
 
-        // low-level tags
-        return output.getElementsByTagName(tagName)[0].parentNode.childNodes;
+        // low-level tag or text
+        default:
+            if (parseFromTemplate) return parseFromTemplate(html);
+            if (parseWithFallback) {
+                return parseWithFallback(html, BODY_TAG_NAME).getElementsByTagName(BODY_TAG_NAME)[0].childNodes;
+            }
+            break;
     }
 
     return [];

--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -1,6 +1,13 @@
 'use strict';
 
 /**
+ * Constants.
+ */
+var HTML_TAG_NAME = 'html';
+var BODY_TAG_NAME = 'body';
+var HEAD_TAG_NAME = 'head';
+
+/**
  * DOMParser.
  *
  * https://developer.mozilla.org/docs/Web/API/DOMParser#Parsing_an_SVG_or_HTML_document
@@ -8,15 +15,16 @@
 var parse;
 if (typeof DOMParser === 'function') {
     var parser = new DOMParser();
+    var MIME_TYPE = 'text/' + HTML_TAG_NAME;
 
     /**
-     * Shorthand for `new DOMParser().parseFromString`.
+     * Creates an HTML document using `DOMParser.parseFromString`.
      *
      * @param  {String} html - The HTML string.
      * @return {HTMLDocument}
      */
     parse = function parseFromString(html) {
-        return parser.parseFromString(html, 'text/html');
+        return parser.parseFromString(html, MIME_TYPE);
     };
 
 /**
@@ -28,7 +36,7 @@ if (typeof DOMParser === 'function') {
     var doc = document.implementation.createHTMLDocument();
 
     /**
-     * Use document created by `document.implementation.createHTMLDocument`.
+     * Use HTML document created by `document.implementation.createHTMLDocument`.
      *
      * @param  {String} html - The HTML string.
      * @return {HTMLDocument}
@@ -55,7 +63,7 @@ if (typeof DOMParser === 'function') {
 }
 
 /**
- * Helper that uses the available parser supported by the browser.
+ * Parses HTML string to DOM nodes.
  *
  * @param  {String} html      - The HTML string.
  * @param  {String} [tagName] - The tag name.
@@ -68,11 +76,11 @@ module.exports = function domparser(html, tagName) {
     if (output instanceof HTMLDocument) {
         // text
         if (!tagName) {
-            return output.getElementsByTagName('body')[0].childNodes;
+            return output.getElementsByTagName(BODY_TAG_NAME)[0].childNodes;
         }
 
         // high-level tags
-        if (['html', 'head', 'body'].indexOf(tagName) !== -1) {
+        if ([HTML_TAG_NAME, HEAD_TAG_NAME, BODY_TAG_NAME].indexOf(tagName) !== -1) {
             return output.getElementsByTagName(tagName);
         }
 

--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -16,8 +16,8 @@ var BODY_REGEX = /<body[\s\S]*>[\s\S]*<\/body>/i;
  * https://developer.mozilla.org/docs/Web/API/DOMParser#Parsing_an_SVG_or_HTML_document
  */
 var parseFromString;
-if (typeof DOMParser === 'function') {
-    var domParser = new DOMParser();
+if (typeof window.DOMParser === 'function') {
+    var domParser = new window.DOMParser();
     var MIME_TYPE = 'text/' + HTML_TAG_NAME;
 
     /**

--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * DOMParser.
+ *
+ * https://developer.mozilla.org/docs/Web/API/DOMParser#Parsing_an_SVG_or_HTML_document
+ */
+var parse;
+if (typeof DOMParser === 'function') {
+    var parser = new DOMParser();
+
+    /**
+     * Shorthand for `new DOMParser().parseFromString`.
+     *
+     * @param  {String} html - The HTML string.
+     * @return {HTMLDocument}
+     */
+    parse = function parseFromString(html) {
+        return parser.parseFromString(html, 'text/html');
+    };
+
+/**
+ * DOMImplementation.
+ *
+ * https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument
+ */
+} else if (typeof document.implementation === 'object') {
+    var doc = document.implementation.createHTMLDocument();
+
+    /**
+     * Use document created by `document.implementation.createHTMLDocument`.
+     *
+     * @param  {String} html - The HTML string.
+     * @return {HTMLDocument}
+     */
+    parse = function createHTMLDocument(html) {
+        doc.documentElement.innerHTML = html;
+        return doc;
+    };
+}
+
+/**
+ * Helper that uses the available parser supported by the browser.
+ *
+ * @param  {String} html      - The HTML string.
+ * @param  {String} [tagName] - The tag name.
+ * @return {NodeList|Array}
+ */
+module.exports = function domparser(html, tagName) {
+    var output = parse(html);
+
+    if (output instanceof HTMLDocument) {
+        // text
+        if (!tagName) {
+            return output.getElementsByTagName('body')[0].childNodes;
+        }
+
+        // high-level tags
+        if (['html', 'head', 'body'].indexOf(tagName) !== -1) {
+            return output.getElementsByTagName(tagName);
+        }
+
+        // low-level tags
+        return output.getElementsByTagName(tagName)[0].parentNode.childNodes;
+    }
+
+    return [];
+};

--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -6,6 +6,7 @@
 var HTML_TAG_NAME = 'html';
 var BODY_TAG_NAME = 'body';
 var HEAD_TAG_NAME = 'head';
+var TAG_NAME_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
 
 /**
  * DOMParser (performance: slow).
@@ -21,7 +22,7 @@ if (typeof DOMParser === 'function') {
      * Creates an HTML document using `DOMParser.parseFromString`.
      *
      * @param  {String} html      - The HTML string.
-     * @param  {String} [tagName] - The tag to wrap the HTML.
+     * @param  {String} [tagName] - The element to render the HTML.
      * @return {HTMLDocument}
      */
     parseFromString = function domStringParser(html, tagName) {
@@ -89,7 +90,14 @@ var parseWithFallback = parseFromDocument || parseFromString;
  * @param  {String} [tagName] - The tag name.
  * @return {NodeList|Array}
  */
-module.exports = function domparser(html, tagName) {
+module.exports = function domparser(html) {
+    // try to match first tag
+    var tagName;
+    var match = html.match(TAG_NAME_REGEX);
+    if (match && match[1]) {
+        tagName = match[1];
+    }
+
     switch (tagName) {
         case HTML_TAG_NAME:
             if (parseFromString) {

--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -37,6 +37,21 @@ if (typeof DOMParser === 'function') {
         doc.documentElement.innerHTML = html;
         return doc;
     };
+
+/**
+ * Template.
+ *
+ * https://developer.mozilla.org/docs/Web/HTML/Element/template
+ */
+} else {
+    var template = document.createElement('template');
+
+    if (template.content) {
+        parse = function parseTemplate(html) {
+            template.innerHTML = html;
+            return template.content.childNodes;
+        };
+    }
 }
 
 /**
@@ -48,6 +63,7 @@ if (typeof DOMParser === 'function') {
  */
 module.exports = function domparser(html, tagName) {
     var output = parse(html);
+    if (output instanceof NodeList) return output;
 
     if (output instanceof HTMLDocument) {
         // text

--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -6,7 +6,9 @@
 var HTML_TAG_NAME = 'html';
 var BODY_TAG_NAME = 'body';
 var HEAD_TAG_NAME = 'head';
-var TAG_NAME_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
+var FIRST_TAG_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
+var HEAD_REGEX = /<head[\s\S]*>[\s\S]*<\/head>/i;
+var BODY_REGEX = /<body[\s\S]*>[\s\S]*<\/body>/i;
 
 /**
  * DOMParser (performance: slow).
@@ -93,27 +95,56 @@ var parseWithFallback = parseFromDocument || parseFromString;
 module.exports = function domparser(html) {
     // try to match first tag
     var tagName;
-    var match = html.match(TAG_NAME_REGEX);
+    var match = html.match(FIRST_TAG_REGEX);
     if (match && match[1]) {
         tagName = match[1];
     }
 
+    var doc;
+    var element;
+    var elements;
+
     switch (tagName) {
         case HTML_TAG_NAME:
             if (parseFromString) {
-                return parseFromString(html).getElementsByTagName(HTML_TAG_NAME);
+                doc = parseFromString(html);
+
+                // strip elements if not found
+                if (!HEAD_REGEX.test(html)) {
+                    element = doc.getElementsByTagName(HEAD_TAG_NAME)[0];
+                    element.parentNode.removeChild(element);
+                }
+
+                if (!BODY_REGEX.test(html)) {
+                    element = doc.getElementsByTagName(BODY_TAG_NAME)[0];
+                    element.parentNode.removeChild(element);
+                }
+
+                return doc.getElementsByTagName(HTML_TAG_NAME);
             }
             break;
 
         case HEAD_TAG_NAME:
             if (parseWithFallback) {
-                return parseWithFallback(html).getElementsByTagName(HEAD_TAG_NAME);
+                elements = parseWithFallback(html).getElementsByTagName(HEAD_TAG_NAME);
+
+                // account for possibility of sibling
+                if (BODY_REGEX.test(html)) {
+                    return elements[0].parentNode.childNodes;
+                }
+                return elements;
             }
             break;
 
         case BODY_TAG_NAME:
             if (parseWithFallback) {
-                return parseWithFallback(html).getElementsByTagName(BODY_TAG_NAME);
+                elements = parseWithFallback(html).getElementsByTagName(BODY_TAG_NAME);
+
+                // account for possibility of sibling
+                if (HEAD_REGEX.test(html)) {
+                    return elements[0].parentNode.childNodes;
+                }
+                return elements;
             }
             break;
 

--- a/lib/html-to-dom-client.js
+++ b/lib/html-to-dom-client.js
@@ -3,9 +3,15 @@
 /**
  * Module dependencies.
  */
+var domparser = require('./domparser');
 var utilities = require('./utilities');
 var formatDOM = utilities.formatDOM;
-var domparser = require('./domparser');
+
+/**
+ * Constants.
+ */
+var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
+var TAG_NAME_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
 
 /**
  * Parses HTML and reformats DOM nodes output.
@@ -19,20 +25,19 @@ module.exports = function parseDOM(html) {
     }
     if (!html) return [];
 
-    // regex to match directive and first tag
-    var directiveMatch = html.match(/<(![a-zA-Z\s]+)>/); // e.g., <!doctype html>
-    var firstTagMatch = html.match(/<([a-zA-Z]+[0-9]?)/); // e.g., <h1>
+    // directive found
+    var match = html.match(DIRECTIVE_REGEX);
     var directive;
-    var tagName;
-
-    // directive matched
-    if (directiveMatch && directiveMatch[1]) {
-        directive = directiveMatch[1];
+    if (match && match[1]) {
+        directive = match[1];
     }
 
     // first tag name matched
-    if (firstTagMatch && firstTagMatch[1]) {
-        tagName = firstTagMatch[1];
+    var tagName;
+    match = html.match(TAG_NAME_REGEX);
+
+    if (match && match[1]) {
+        tagName = match[1];
     }
 
     return formatDOM(domparser(html, tagName), null, directive);

--- a/lib/html-to-dom-client.js
+++ b/lib/html-to-dom-client.js
@@ -11,7 +11,6 @@ var formatDOM = utilities.formatDOM;
  * Constants.
  */
 var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
-var TAG_NAME_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
 
 /**
  * Parses HTML and reformats DOM nodes output.
@@ -32,13 +31,5 @@ module.exports = function parseDOM(html) {
         directive = match[1];
     }
 
-    // first tag name matched
-    var tagName;
-    match = html.match(TAG_NAME_REGEX);
-
-    if (match && match[1]) {
-        tagName = match[1];
-    }
-
-    return formatDOM(domparser(html, tagName), null, directive);
+    return formatDOM(domparser(html), null, directive);
 };

--- a/lib/html-to-dom-client.js
+++ b/lib/html-to-dom-client.js
@@ -5,96 +5,35 @@
  */
 var utilities = require('./utilities');
 var formatDOM = utilities.formatDOM;
+var domparser = require('./domparser');
 
 /**
- * Parse HTML string to DOM nodes.
- * This uses the browser DOM API.
+ * Parses HTML and reformats DOM nodes output.
  *
- * @param  {String} html - The HTML.
- * @return {Object}      - The DOM nodes.
+ * @param  {String} html - The HTML string.
+ * @return {Array}       - The formatted DOM nodes.
  */
-function parseDOM(html) {
+module.exports = function parseDOM(html) {
     if (typeof html !== 'string') {
         throw new TypeError('First argument must be a string.');
     }
+    if (!html) return [];
 
-    // try to match the tags
-    var match = html.match(/<[^\/](.+?)>/g);
-    var nodes;
+    // regex to match directive and first tag
+    var directiveMatch = html.match(/<(![a-zA-Z\s]+)>/); // e.g., <!doctype html>
+    var firstTagMatch = html.match(/<([a-zA-Z]+[0-9]?)/); // e.g., <h1>
+    var directive;
+    var tagName;
 
-    if (match && match.length) {
-        var tagMatch = match[0];
-
-        // directive matched
-        if (/<![^-]/.test(tagMatch)) {
-            var directive = (
-                // remove angle brackets
-                tagMatch
-                    .substring(1, tagMatch.length - 1)
-                    .trim()
-            );
-
-            // tag name can no longer be first match item
-            tagMatch = match[1];
-
-            // remove directive from html
-            html = html.substring(html.indexOf('>') + 1);
-        }
-
-        // first tag name matched
-        if (tagMatch) {
-            var tagName = (
-                // keep only tag name
-                tagMatch
-                    .substring(1, tagMatch.indexOf(' '))
-                    .trim()
-                    .toLowerCase()
-            )
-        }
+    // directive matched
+    if (directiveMatch && directiveMatch[1]) {
+        directive = directiveMatch[1];
     }
 
-    // create html document to parse top-level nodes
-    if (['html', 'head', 'body'].indexOf(tagName) > -1) {
-        var doc;
-
-        // `new DOMParser().parseFromString()`
-        // https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#Parsing_an_SVG_or_HTML_document
-        if (window.DOMParser) {
-            doc = new window.DOMParser().parseFromString(html, 'text/html');
-
-        // `DOMImplementation.createHTMLDocument()`
-        // https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument
-        } else if (document.implementation.createHTMLDocument) {
-            doc = document.implementation.createHTMLDocument();
-            doc.documentElement.innerHTML = html;
-            doc.removeChild(doc.childNodes[0]); // remove doctype
-        }
-
-        // html
-        if (tagName === 'html') {
-            nodes = doc.childNodes;
-        // head and body
-        } else {
-            nodes = (
-                // do this so attributes are kept
-                // but there may be an extra head/body node
-                doc.getElementsByTagName(tagName)[0]
-                    .parentNode
-                    .childNodes
-            );
-        }
-
-    // `innerHTML` approach
-    } else {
-        var container = document.createElement('body');
-        container.innerHTML = html;
-        nodes = container.childNodes;
+    // first tag name matched
+    if (firstTagMatch && firstTagMatch[1]) {
+        tagName = firstTagMatch[1];
     }
 
-    return formatDOM(nodes, null, directive);
-}
-
-/**
- * Export HTML to DOM parser (client).
- */
-module.exports = parseDOM;
+    return formatDOM(domparser(html, tagName), null, directive);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -54,16 +54,9 @@ describe('html-dom-parser', function() {
 
     // client
     describe('client parser', function() {
-        var parser = require('../lib/html-to-dom-client');
         var jsdomify = require('jsdomify').default;
-
-        before(function() {
-            jsdomify.create();
-        });
-
-        after(function() {
-            jsdomify.destroy();
-        });
+        jsdomify.create();
+        var parser = require('../lib/html-to-dom-client');
 
         // check if invalid parameter type throws error
         throwTests(parser);
@@ -72,6 +65,8 @@ describe('html-dom-parser', function() {
         runTests(parser, fixtures.html);
         // svg does not work in jsdom
         // runTests(parser, fixtures.svg);
+
+        jsdomify.destroy();
     });
 
 });


### PR DESCRIPTION
Resolves #1

#### Tasks:
- Modularize `lib/domparser.js` from `lib/html-to-dom-client.js`
- Improve client parser
  - Use [template](https://developer.mozilla.org/docs/Web/HTML/Element/template) as a more performant way of parsing HTML without loading external resources like images
  - Ensure the parser fallbacks to `DOMImplementation` and then `DOMParser` (based on performance)
  - HTML with `<html>` tags will be parsed by `DOMParser`
    - Make sure to prune extraneous tags (e.g., `<head>` or `<body>`) if not in the HTML
  - Improve regex and create constants
- Fix tests

#### Misc:
- [Spike](https://gist.github.com/remarkablemark/c23f93fc4ef1b2a977459b32a46aaafb)