### PR TITLE
Specify title parameter for `document.implementation.createHTMLDocument`

### DIFF
--- a/lib/domparser.js
+++ b/lib/domparser.js
@@ -42,7 +42,10 @@ if (typeof window.DOMParser === 'function') {
  */
 var parseFromDocument;
 if (typeof document.implementation === 'object') {
-    var doc = document.implementation.createHTMLDocument();
+    // title parameter is required in IE
+    var doc = document.implementation.createHTMLDocument('title');
+    // remove the title
+    doc.documentElement.innerHTML = '';
 
     /**
      * Use HTML document created by `document.implementation.createHTMLDocument`.

--- a/test/index.js
+++ b/test/index.js
@@ -63,8 +63,7 @@ describe('html-dom-parser', function() {
 
         // should return the same output as `htmlparser2.parseDOM()`
         runTests(parser, fixtures.html);
-        // svg does not work in jsdom
-        // runTests(parser, fixtures.svg);
+        runTests(parser, fixtures.svg);
 
         jsdomify.destroy();
     });


### PR DESCRIPTION
Fixes #3

#### Tasks:
- The first parameter for [`createHTMLDocument`](https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument#Parameters) is **required** in IE

#### Misc:
- Enable svg tests for client parser (current version of `jsdom` supports svg)