### PR TITLE
build(rollup): use rollup to build browser bundle

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 6,
+    "sourceType": "module"
   },
   "plugins": ["prettier"],
   "rules": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "index.js",
   "scripts": {
-    "build": "run-s build:*",
-    "build:min": "webpack index.js -o dist/html-dom-parser.min.js --mode production --output-library HTMLDOMParser --output-library-target umd",
-    "build:unmin": "webpack index.js -o dist/html-dom-parser.js --mode development --output-library HTMLDOMParser --output-library-target umd",
+    "build": "rollup --config",
     "clean": "rm -rf dist",
     "lint": "eslint . --ignore-path .gitignore",
     "lint:dts": "dtslint .",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
+    "@rollup/plugin-commonjs": "^12.0.0",
+    "@rollup/plugin-node-resolve": "^8.0.0",
     "chai": "^4.2.0",
     "dtslint": "^3.6.9",
     "eslint": "^7.1.0",
@@ -66,6 +68,8 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.0.5",
+    "rollup": "^2.12.1",
+    "rollup-plugin-uglify": "^6.0.4",
     "sinon": "^9.0.2",
     "standard-version": "^6",
     "typescript": "^3.9.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,22 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import { uglify } from 'rollup-plugin-uglify';
+
+/**
+ * Build rollup config for development (default) or production (minify = true).
+ *
+ * @param {Boolean} [minify=false]
+ * @return {Object}
+ */
+const getConfig = (minify = false) => ({
+  input: 'index.js',
+  output: {
+    file: `dist/html-dom-parser${minify ? '.min' : ''}.js`,
+    format: 'umd',
+    name: 'HTMLDOMParser',
+    sourcemap: true
+  },
+  plugins: [commonjs(), resolve({ browser: true }), minify && uglify()]
+});
+
+export default [getConfig(), getConfig(true)];


### PR DESCRIPTION
| file | webpack | rollup |
| :--- | :---: | :---: |
| `html-dom-parser.js` | 16.3 KB | 12 KB |
| `html-dom-parser.min.js` | 4.39 KB | 3.3 KB |
| `html-dom-parser.js.map` | - | 20 KB |
| `html-dom-parser.min.js.map` | - | 15 KB |

Include sourcemaps for min and unmin bundles