### PR TITLE
chore: update README and refactor tests and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ $ git push --follow-tags && npm publish
 
 - [Contributors](https://github.com/remarkablemark/html-dom-parser/graphs/contributors)
 - [htmlparser2](https://github.com/fb55/htmlparser2)
+- [domhandler](https://github.com/fb55/domhandler)
 
 ## License
 

--- a/lib/domparser.d.ts
+++ b/lib/domparser.d.ts
@@ -3,7 +3,7 @@
 /**
  * Parses HTML string to DOM nodes.
  *
- * @param  - HTML markup.
- * @return - NodeList.
+ * @param  html - HTML markup.
+ * @return      - NodeList.
  */
 export default function domparser(html: string): NodeList;

--- a/lib/html-to-dom-client.d.ts
+++ b/lib/html-to-dom-client.d.ts
@@ -5,7 +5,7 @@ import { DomElement } from 'domhandler';
 /**
  * Parses HTML string to DOM nodes in browser.
  *
- * @param  - HTML markup.
- * @return - DOM elements.
+ * @param  html - HTML markup.
+ * @return      - DOM elements.
  */
 export default function HTMLDOMParser(html: string): DomElement[];

--- a/lib/html-to-dom-server.d.ts
+++ b/lib/html-to-dom-server.d.ts
@@ -8,9 +8,9 @@ import { DomHandlerOptions, DomElement } from 'domhandler';
  * This is the same method as `require('htmlparser2').parseDOM`
  * https://github.com/fb55/htmlparser2/blob/v3.9.1/lib/index.js#L39-L43
  *
- * @param  - HTML markup.
- * @param  - Parser options (https://github.com/fb55/domhandler/tree/v2.4.2#readme).
- * @return - DOM elements.
+ * @param  html    - HTML markup.
+ * @param  options - Parser options (https://github.com/fb55/domhandler/tree/v2.4.2#readme).
+ * @return         - DOM elements.
  */
 export default function HTMLDOMParser(
   html: string,

--- a/test/helpers/cycle.js
+++ b/test/helpers/cycle.js
@@ -1,0 +1,182 @@
+/**
+ * @see {@link https://github.com/douglascrockford/JSON-js/blob/master/cycle.js}
+ */
+
+/*
+    cycle.js
+    2018-05-15
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+*/
+
+// The file uses the WeakMap feature of ES6.
+
+/* jslint eval */
+
+/* property
+    $ref, decycle, forEach, get, indexOf, isArray, keys, length, push,
+    retrocycle, set, stringify, test
+*/
+
+if (typeof JSON.decycle !== 'function') {
+  JSON.decycle = function decycle(object, replacer) {
+    'use strict';
+
+    // Make a deep copy of an object or array, assuring that there is at most
+    // one instance of each object or array in the resulting structure. The
+    // duplicate references (which might be forming cycles) are replaced with
+    // an object of the form
+
+    //      {"$ref": PATH}
+
+    // where the PATH is a JSONPath string that locates the first occurance.
+
+    // So,
+
+    //      var a = [];
+    //      a[0] = a;
+    //      return JSON.stringify(JSON.decycle(a));
+
+    // produces the string '[{"$ref":"$"}]'.
+
+    // If a replacer function is provided, then it will be called for each value.
+    // A replacer function receives a value and returns a replacement value.
+
+    // JSONPath is used to locate the unique object. $ indicates the top level of
+    // the object or array. [NUMBER] or [STRING] indicates a child element or
+    // property.
+
+    var objects = new window.WeakMap(); // object to path mappings
+
+    return (function derez(value, path) {
+      // The derez function recurses through the object, producing the deep copy.
+
+      var old_path; // The path of an earlier occurance of value
+      var nu; // The new object or array
+
+      // If a replacer function was provided, then call it to get a replacement value.
+
+      if (replacer !== undefined) {
+        value = replacer(value);
+      }
+
+      // typeof null === "object", so go on if this value is really an object but not
+      // one of the weird builtin objects.
+
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        !(value instanceof Boolean) &&
+        !(value instanceof Date) &&
+        !(value instanceof Number) &&
+        !(value instanceof RegExp) &&
+        !(value instanceof String)
+      ) {
+        // If the value is an object or array, look to see if we have already
+        // encountered it. If so, return a {"$ref":PATH} object. This uses an
+        // ES6 WeakMap.
+
+        old_path = objects.get(value);
+        if (old_path !== undefined) {
+          return { $ref: old_path };
+        }
+
+        // Otherwise, accumulate the unique value and its path.
+
+        objects.set(value, path);
+
+        // If it is an array, replicate the array.
+
+        if (Array.isArray(value)) {
+          nu = [];
+          value.forEach(function (element, i) {
+            nu[i] = derez(element, path + '[' + i + ']');
+          });
+        } else {
+          // If it is an object, replicate the object.
+
+          nu = {};
+          Object.keys(value).forEach(function (name) {
+            nu[name] = derez(
+              value[name],
+              path + '[' + JSON.stringify(name) + ']'
+            );
+          });
+        }
+        return nu;
+      }
+      return value;
+    })(object, '$');
+  };
+}
+
+if (typeof JSON.retrocycle !== 'function') {
+  JSON.retrocycle = function retrocycle($) {
+    'use strict';
+
+    // Restore an object that was reduced by decycle. Members whose values are
+    // objects of the form
+    //      {$ref: PATH}
+    // are replaced with references to the value found by the PATH. This will
+    // restore cycles. The object will be mutated.
+
+    // The eval function is used to locate the values described by a PATH. The
+    // root object is kept in a $ variable. A regular expression is used to
+    // assure that the PATH is extremely well formed. The regexp contains nested
+    // * quantifiers. That has been known to have extremely bad performance
+    // problems on some browsers for very long strings. A PATH is expected to be
+    // reasonably short. A PATH is allowed to belong to a very restricted subset of
+    // Goessner's JSONPath.
+
+    // So,
+    //      var s = '[{"$ref":"$"}]';
+    //      return JSON.retrocycle(JSON.parse(s));
+    // produces an array containing a single element which is the array itself.
+
+    // eslint-disable-next-line no-control-regex
+    var px = /^\$(?:\[(?:\d+|"(?:[^\\"\u0000-\u001f]|\\(?:[\\"/bfnrt]|u[0-9a-zA-Z]{4}))*")\])*$/;
+
+    (function rez(value) {
+      // The rez function walks recursively through the object looking for $ref
+      // properties. When it finds one that has a value that is a path, then it
+      // replaces the $ref object with a reference to the value that is found by
+      // the path.
+
+      if (value && typeof value === 'object') {
+        if (Array.isArray(value)) {
+          value.forEach(function (element, i) {
+            if (typeof element === 'object' && element !== null) {
+              var path = element.$ref;
+              if (typeof path === 'string' && px.test(path)) {
+                value[i] = eval(path);
+              } else {
+                rez(element);
+              }
+            }
+          });
+        } else {
+          Object.keys(value).forEach(function (name) {
+            var item = value[name];
+            if (typeof item === 'object' && item !== null) {
+              var path = item.$ref;
+              if (typeof path === 'string' && px.test(path)) {
+                value[name] = eval(path);
+              } else {
+                rez(item);
+              }
+            }
+          });
+        }
+      }
+    })($);
+    return $;
+  };
+}

--- a/test/helpers/run-tests.js
+++ b/test/helpers/run-tests.js
@@ -8,17 +8,17 @@
  */
 function runTests(assert, actualParser, expectedParser, testCases) {
   // enable `decodeEntities` for both parsers
-  // because entities are decoded on the browser
+  // because entities are decoded in the browser
   var parserOptions = { decodeEntities: true };
 
   testCases.forEach(function (testCase) {
     var _it = testCase.only ? it.only : testCase.skip ? it.skip : it;
 
     _it('parses ' + testCase.name, function () {
-      assert.deepEqual(
-        actualParser(testCase.data, parserOptions),
-        expectedParser(testCase.data, parserOptions)
-      );
+      var actualOutput = actualParser(testCase.data, parserOptions);
+      var expectedOutput = expectedParser(testCase.data, parserOptions);
+
+      assert.deepEqual(actualOutput, expectedOutput);
     });
   });
 }

--- a/test/helpers/throw-errors.js
+++ b/test/helpers/throw-errors.js
@@ -19,7 +19,10 @@ var values = [
  */
 function throwErrors(assert, expectedParser) {
   values.forEach(function (value) {
-    it('throws error for argument: ' + value, function () {
+    var type =
+      value instanceof Object ? value.constructor.name : JSON.stringify(value);
+
+    it('throws error for argument: ' + type, function () {
       assert.throws(function () {
         expectedParser(value);
       }, TypeError);

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -35,26 +35,26 @@ describe('server parser', () => {
   mock('domhandler', DomHandler);
   const parse = require('../..');
 
-  it('calls `domhandler` and `htmlparser2/lib/Parser`', () => {
+  it('calls `DomHandler` and `Parser`', () => {
     parse(html);
     expect(DomHandler.called).to.equal(true);
     expect(Parser.called).to.equal(true);
     expect(parserEnd.called).to.equal(true);
   });
 
-  it('passes options to `domhandler` and arguments to `htmlparser2/lib/Parser`', () => {
+  it('passes options to `DomHandler` and `Parser`', () => {
     const options = { decodeEntities: true };
     parse(html, options);
     expect(DomHandler.calledWith(options)).to.equal(true);
     expect(Parser.calledWith(DomHandler, options));
   });
 
-  it('passes html to `htmlparser2/lib/Parser` end', () => {
+  it('passes html to `Parser` end', () => {
     parse(html);
     expect(parserEnd.calledWith(html)).to.equal(true);
   });
 
-  it('returns `domhandler` dom', () => {
+  it('returns `DomHandler` dom', () => {
     expect(parse(html)).to.equal(DomHandler.lastCall.returnValue.dom);
   });
 


### PR DESCRIPTION
## What is the motivation for this pull request?

chore: update README.md and refactor tests and types

- Added `domhandler` link to README
- For test helpers, added [cycle.js](https://github.com/douglascrockford/JSON-js/blob/master/cycle.js), which will be used by Karma client tests later after `htmlparser2` major upgrade
- Improve JSDoc in type declaration files

## Checklist:

- [x] Tests
- [x] Types
- [x] Documentation
