### PR TITLE
feat: upgrade `domhandler` to 3.3.0 and `htmlparser2` to 4.1.0

### DIFF
--- a/lib/html-to-dom-server.d.ts
+++ b/lib/html-to-dom-server.d.ts
@@ -1,18 +1,24 @@
 // TypeScript Version: 4.1
 
-import { DataNode, DomHandlerOptions, Element } from 'domhandler';
+import {
+  Comment,
+  DomHandlerOptions,
+  Element,
+  ProcessingInstruction,
+  Text
+} from 'domhandler';
 
 /**
  * Parses HTML string to DOM nodes in Node.js.
  *
  * This is the same method as `require('htmlparser2').parseDOM`
- * https://github.com/fb55/htmlparser2/blob/v4.0.0/src/index.ts#L18-L22
+ * https://github.com/fb55/htmlparser2/blob/v4.1.0/src/index.ts#L18-L22
  *
  * @param  html    - HTML markup.
- * @param  options - Parser options (https://github.com/fb55/domhandler/tree/v3.0.0#readme).
- * @return         - DOM elements.
+ * @param  options - Parser options (https://github.com/fb55/domhandler/tree/v3.3.0#readme).
+ * @return         - DOM nodes.
  */
 export default function HTMLDOMParser(
   html: string,
   options?: DomHandlerOptions
-): Array<DataNode | Element>;
+): Array<Comment | Element | ProcessingInstruction | Text>;

--- a/lib/html-to-dom-server.js
+++ b/lib/html-to-dom-server.js
@@ -5,11 +5,11 @@ var DomHandler = require('domhandler').DomHandler;
  * Parses HTML string to DOM nodes in Node.js.
  *
  * This is the same method as `require('htmlparser2').parseDOM`
- * https://github.com/fb55/htmlparser2/blob/v4.0.0/src/index.ts#L18-L22
+ * https://github.com/fb55/htmlparser2/blob/v4.1.0/src/index.ts#L18-L22
  *
  * @param  {string}            html      - HTML markup.
- * @param  {DomHandlerOptions} [options] - Parser options (https://github.com/fb55/domhandler/tree/v3.0.0#readme).
- * @return {DomElement[]}                - DOM elements.
+ * @param  {DomHandlerOptions} [options] - Parser options (https://github.com/fb55/domhandler/tree/v3.3.0#readme).
+ * @return {Array<Comment|Element|ProcessingInstruction|Text>} - DOM nodes.
  */
 function HTMLDOMParser(html, options) {
   if (typeof html !== 'string') {

--- a/lib/utilities.d.ts
+++ b/lib/utilities.d.ts
@@ -1,6 +1,6 @@
 // TypeScript Version: 4.1
 
-import { DataNode, Element } from 'domhandler';
+import { Comment, Element, ProcessingInstruction, Text } from 'domhandler';
 
 /**
  * Formats DOM attributes to a hash map.
@@ -22,9 +22,9 @@ export function formatAttributes(
  */
 export function formatDOM(
   nodes: NodeList,
-  parentNode?: DataNode | Element,
+  parentNode?: Element,
   directive?: string
-): Array<DataNode | Element>;
+): Array<Comment | Element | ProcessingInstruction | Text>;
 
 /**
  * Detects if browser is Internet Explorer.

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,9 +3,10 @@ var domhandler = require('domhandler/lib/node');
 
 var CASE_SENSITIVE_TAG_NAMES = constants.CASE_SENSITIVE_TAG_NAMES;
 
+var Comment = domhandler.Comment;
 var Element = domhandler.Element;
-var DataNode = domhandler.DataNode;
 var ProcessingInstruction = domhandler.ProcessingInstruction;
+var Text = domhandler.Text;
 
 var caseSensitiveTagNamesMap = {};
 var tagName;
@@ -61,10 +62,10 @@ function formatTagName(tagName) {
 /**
  * Formats the browser DOM nodes to mimic the output of `htmlparser2.parseDOM()`.
  *
- * @param  {NodeList}               nodes        - DOM nodes.
- * @param  {DataNode|Element}       [parentNode] - Formatted parent node.
- * @param  {string}                 [directive]  - Directive.
- * @return {Array<DomNode|Element>}              - Formatted DOM object.
+ * @param  {NodeList} nodes        - DOM nodes.
+ * @param  {Element}  [parentNode] - Formatted parent node.
+ * @param  {string}   [directive]  - Directive.
+ * @return {Array<Comment|Element|ProcessingInstruction|Text>}
  */
 function formatDOM(domNodes, parentNode, directive) {
   parentNode = parentNode || null;
@@ -89,11 +90,11 @@ function formatDOM(domNodes, parentNode, directive) {
         break;
 
       case 3:
-        node = new DataNode('text', domNode.nodeValue);
+        node = new Text(domNode.nodeValue);
         break;
 
       case 8:
-        node = new DataNode('comment', domNode.nodeValue);
+        node = new Comment(domNode.nodeValue);
         break;
     }
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "pojo"
   ],
   "dependencies": {
-    "domhandler": "3.0.0",
-    "htmlparser2": "4.0.0"
+    "domhandler": "3.3.0",
+    "htmlparser2": "4.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -1,16 +1,16 @@
 import parse from 'html-dom-parser';
 
-// $ExpectType (DataNode | Element)[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 parse('<div>text</div>');
 
-// $ExpectType (DataNode | Element)[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 parse('<div>text</div>', { normalizeWhitespace: true });
 
-// $ExpectType (DataNode | Element)[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 parse('<div>text</div>', { withStartIndices: true });
 
-// $ExpectType (DataNode | Element)[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 parse('<div>text</div>', { withEndIndices: true });
 
-// $ExpectType (DataNode | Element)[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 parse('');


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: upgrade `domhandler` to 3.3.0 and `htmlparser2` to 4.1.0

```
 domhandler   3.0.0  →  3.3.0
 htmlparser2  4.0.0  →  4.1.0
```

## What is the current behavior?

dependencies:

- [`domhandler`@3.0.0](https://github.com/fb55/domhandler/releases/tag/v3.0.0)
- [`htmlparser2`@4.0.0](https://github.com/fb55/htmlparser2/releases/tag/v4.0.0)

## What is the new behavior?

dependencies:

- [`domhandler`@3.3.0](https://github.com/fb55/domhandler/releases/tag/v3.3.0)
- [`htmlparser2`@4.1.0](https://github.com/fb55/htmlparser2/releases/tag/v4.1.0)

Replace domhandler `DataNode` with `Comment` and `Text`.

## Checklist:

- [x] Tests
- [x] Types
- [ ] Documentation
