### PR TITLE
refactor(utilities): tidy types, JSDoc, and rename variables

### DIFF
--- a/lib/utilities.d.ts
+++ b/lib/utilities.d.ts
@@ -10,19 +10,19 @@ import { Comment, Element, ProcessingInstruction, Text } from 'domhandler';
  */
 export function formatAttributes(
   attributes: NamedNodeMap
-): { [name: string]: string };
+): Record<string, string>;
 
 /**
- * Formats the browser DOM nodes to mimic the output of `htmlparser2.parseDOM()`.
+ * Transforms DOM nodes to `domhandler` nodes.
  *
- * @param  nodes      - DOM nodes.
- * @param  parentNode - Formatted parent node.
- * @param  directive  - Directive.
- * @return            - DOM elements.
+ * @param  nodes     - DOM nodes.
+ * @param  parent    - Parent node.
+ * @param  directive - Directive.
+ * @return           - Nodes.
  */
 export function formatDOM(
   nodes: NodeList,
-  parentNode?: Element,
+  parent?: Element | null,
   directive?: string
 ): Array<Comment | Element | ProcessingInstruction | Text>;
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -93,6 +93,9 @@ function formatDOM(nodes, parent, directive) {
       case 8:
         current = new Comment(node.nodeValue);
         break;
+
+      default:
+        continue;
     }
 
     // set previous node next

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -60,73 +60,70 @@ function formatTagName(tagName) {
 }
 
 /**
- * Formats the browser DOM nodes to mimic the output of `htmlparser2.parseDOM()`.
+ * Transforms DOM nodes to `domhandler` nodes.
  *
- * @param  {NodeList} nodes        - DOM nodes.
- * @param  {Element}  [parentNode] - Formatted parent node.
- * @param  {string}   [directive]  - Directive.
+ * @param  {NodeList}     nodes         - DOM nodes.
+ * @param  {Element|null} [parent=null] - Parent node.
+ * @param  {string}       [directive]   - Directive.
  * @return {Array<Comment|Element|ProcessingInstruction|Text>}
  */
-function formatDOM(domNodes, parentNode, directive) {
-  parentNode = parentNode || null;
+function formatDOM(nodes, parent, directive) {
+  parent = parent || null;
+  var result = [];
 
-  var domNode;
-  var node;
-  var prevNode;
-  var output = [];
-
-  for (var i = 0, len = domNodes.length; i < len; i++) {
-    domNode = domNodes[i];
+  for (var index = 0, len = nodes.length; index < len; index++) {
+    var node = nodes[index];
+    var current;
 
     // set the node data given the type
-    switch (domNode.nodeType) {
+    switch (node.nodeType) {
       case 1:
         // script, style, or tag
-        node = new Element(
-          formatTagName(domNode.nodeName),
-          formatAttributes(domNode.attributes)
+        current = new Element(
+          formatTagName(node.nodeName),
+          formatAttributes(node.attributes)
         );
-        node.children = formatDOM(domNode.childNodes, node);
+        current.children = formatDOM(node.childNodes, current);
         break;
 
       case 3:
-        node = new Text(domNode.nodeValue);
+        current = new Text(node.nodeValue);
         break;
 
       case 8:
-        node = new Comment(domNode.nodeValue);
+        current = new Comment(node.nodeValue);
         break;
     }
 
-    // set next for previous node
-    prevNode = output[i - 1] || null;
-    if (prevNode) {
-      prevNode.next = node;
+    // set previous node next
+    var prev = result[index - 1] || null;
+    if (prev) {
+      prev.next = current;
     }
 
     // set properties for current node
-    node.parent = parentNode;
-    node.prev = prevNode;
-    node.next = null;
+    current.parent = parent;
+    current.prev = prev;
+    current.next = null;
 
-    output.push(node);
+    result.push(current);
   }
 
   if (directive) {
-    node = new ProcessingInstruction(
+    current = new ProcessingInstruction(
       directive.substring(0, directive.indexOf(' ')).toLowerCase(),
       directive
     );
-    node.next = output[0] || null;
-    node.parent = parentNode;
-    output.unshift(node);
+    current.next = result[0] || null;
+    current.parent = parent;
+    result.unshift(current);
 
-    if (output[1]) {
-      output[1].prev = output[0];
+    if (result[1]) {
+      result[1].prev = result[0];
     }
   }
 
-  return output;
+  return result;
 }
 
 /**

--- a/test/cases/html.js
+++ b/test/cases/html.js
@@ -55,6 +55,18 @@ module.exports = [
     data: '<head><body>'
   },
   {
+    name: 'unclosed title',
+    data: '<title>'
+  },
+  {
+    name: 'empty title',
+    data: '<title></title>'
+  },
+  {
+    name: 'title with text',
+    data: '<title>text</title>'
+  },
+  {
     name: 'unclosed body',
     data: '<body>'
   },
@@ -221,6 +233,14 @@ module.exports = [
   {
     name: 'non-breaking space',
     data: '&nbsp;'
+  },
+  {
+    name: 'en dash',
+    data: '&ndash;'
+  },
+  {
+    name: 'em dash',
+    data: '&mdash;'
   },
 
   // directive


### PR DESCRIPTION
## What is the motivation for this pull request?

refactor(utilities): tidy types, JSDoc, and rename variables

Continue in `formatDOM` if nodeType does not match cases

Add additional HTML test cases (title and entities)

## Checklist:

- [x] Tests
- [x] Types
