### PR TITLE
build(package): upgrade `domhandler` to v4 and `htmlparser2` to v6

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = config => {
     ],
 
     // list of files / patterns to exclude
-    exclude: ['lib/server/**/*.js'],
+    exclude: ['lib/server/html-to-dom.js'],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/lib/server/html-to-dom.d.ts
+++ b/lib/server/html-to-dom.d.ts
@@ -12,10 +12,10 @@ import {
  * Parses HTML string to DOM nodes in Node.js.
  *
  * This is the same method as `require('htmlparser2').parseDOM`
- * https://github.com/fb55/htmlparser2/blob/v4.1.0/src/index.ts#L18-L22
+ * https://github.com/fb55/htmlparser2/blob/v6.0.0/src/index.ts#L29-L41
  *
  * @param  html    - HTML markup.
- * @param  options - Parser options (https://github.com/fb55/domhandler/tree/v3.3.0#readme).
+ * @param  options - Parser options (https://github.com/fb55/domhandler/tree/v4.0.0#readme).
  * @return         - DOM nodes.
  */
 export default function HTMLDOMParser(

--- a/lib/server/html-to-dom.js
+++ b/lib/server/html-to-dom.js
@@ -1,14 +1,16 @@
 var Parser = require('htmlparser2/lib/Parser').Parser;
 var DomHandler = require('domhandler').DomHandler;
 
+var unsetRootParent = require('./utilities').unsetRootParent;
+
 /**
  * Parses HTML string to DOM nodes in Node.js.
  *
  * This is the same method as `require('htmlparser2').parseDOM`
- * https://github.com/fb55/htmlparser2/blob/v4.1.0/src/index.ts#L18-L22
+ * https://github.com/fb55/htmlparser2/blob/v6.0.0/src/index.ts#L29-L41
  *
  * @param  {string}            html      - HTML markup.
- * @param  {DomHandlerOptions} [options] - Parser options (https://github.com/fb55/domhandler/tree/v3.3.0#readme).
+ * @param  {DomHandlerOptions} [options] - Parser options (https://github.com/fb55/domhandler/tree/v4.0.0#readme).
  * @return {Array<Comment|Element|ProcessingInstruction|Text>} - DOM nodes.
  */
 function HTMLDOMParser(html, options) {
@@ -16,13 +18,13 @@ function HTMLDOMParser(html, options) {
     throw new TypeError('First argument must be a string.');
   }
 
-  if (!html) {
+  if (html === '') {
     return [];
   }
 
   var handler = new DomHandler(undefined, options);
   new Parser(handler, options).end(html);
-  return handler.dom;
+  return unsetRootParent(handler.dom);
 }
 
 module.exports = HTMLDOMParser;

--- a/lib/server/utilities.d.ts
+++ b/lib/server/utilities.d.ts
@@ -1,0 +1,11 @@
+// TypeScript Version: 4.1
+
+type Nodes = Array<Comment | Element | ProcessingInstruction | Text>;
+
+/**
+ * Sets root parent to null.
+ *
+ * @param nodes
+ * @return
+ */
+export function unsetRootParent(nodes: Nodes): Nodes;

--- a/lib/server/utilities.js
+++ b/lib/server/utilities.js
@@ -1,0 +1,17 @@
+/**
+ * Sets root parent to null.
+ *
+ * @param  {Array<Comment|Element|ProcessingInstruction|Text>} nodes
+ * @return {Array<Comment|Element|ProcessingInstruction|Text>}
+ */
+function unsetRootParent(nodes) {
+  for (var index = 0, len = nodes.length; index < len; index++) {
+    var node = nodes[index];
+    node.parent = null;
+  }
+  return nodes;
+}
+
+module.exports = {
+  unsetRootParent: unsetRootParent
+};

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "pojo"
   ],
   "dependencies": {
-    "domhandler": "3.3.0",
-    "htmlparser2": "4.1.0"
+    "domhandler": "4.0.0",
+    "htmlparser2": "6.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/test/helpers/run-tests.js
+++ b/test/helpers/run-tests.js
@@ -1,3 +1,5 @@
+var unsetRootParent = require('../../lib/server/utilities').unsetRootParent;
+
 var isKarma =
   typeof window === 'object' && typeof window.__karma__ === 'object';
 
@@ -10,16 +12,12 @@ var isKarma =
  * @param {Function} expectedParser - Expected parser.
  */
 function runTests(assert, actualParser, expectedParser, testCases) {
-  // enable `decodeEntities` for both parsers
-  // because entities are decoded in the browser
-  var parserOptions = { decodeEntities: true };
-
   testCases.forEach(function (testCase) {
     var _it = testCase.only ? it.only : testCase.skip ? it.skip : it;
 
     _it('parses ' + testCase.name, function () {
-      var actualOutput = actualParser(testCase.data, parserOptions);
-      var expectedOutput = expectedParser(testCase.data, parserOptions);
+      var actualOutput = actualParser(testCase.data);
+      var expectedOutput = unsetRootParent(expectedParser(testCase.data));
 
       // use `JSON.decycle` since `assert.deepEqual` fails
       // when instance types are different in the browser


### PR DESCRIPTION
## What is the motivation for this pull request?

BREAKING CHANGE: upgrade `domhandler` to v4 and `htmlparser2` to v6

```
 domhandler   3.3.0  →  4.0.0
 htmlparser2  4.1.0  →  6.0.0
```

domhandler:

* https://github.com/fb55/domhandler/releases/tag/v4.0.0

htmlparser2:

* https://github.com/fb55/htmlparser2/releases/tag/v5.0.0
* https://github.com/fb55/htmlparser2/releases/tag/v5.0.1
* https://github.com/fb55/htmlparser2/releases/tag/v6.0.0

`decodeEntities` option now defaults to true. `<title>` is parsed correctly. Remove root parent node to keep parser backwards compatible.

## Checklist:

- [x] Tests
- [x] Types
- [ ] Documentation
