### PR TITLE
perf(client): deprecate Internet Explorer 9 (IE9)

### DIFF
--- a/lib/client/domparser.js
+++ b/lib/client/domparser.js
@@ -7,12 +7,9 @@ var BODY = 'body';
 var FIRST_TAG_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
 var HEAD_TAG_REGEX = /<head.*>/i;
 var BODY_TAG_REGEX = /<body.*>/i;
-// http://www.w3.org/TR/html/syntax.html#void-elements
-var VOID_ELEMENTS_REGEX = /<(area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)(.*?)\/?>/gi;
 
-// detect IE browser
-var isIE9 = utilities.isIE(9);
-var isIE = isIE9 || utilities.isIE();
+// detect Internet Explorer
+var isIE = utilities.isIE();
 
 // falls back to `parseFromString` if `createHTMLDocument` cannot be used
 var parseFromDocument = function () {
@@ -34,10 +31,7 @@ var parseFromString = function () {
  */
 if (typeof window.DOMParser === 'function') {
   var domParser = new window.DOMParser();
-
-  // IE9 does not support 'text/html' MIME type
-  // https://msdn.microsoft.com/en-us/library/ff975278(v=vs.85).aspx
-  var mimeType = isIE9 ? 'text/xml' : 'text/html';
+  var mimeType = 'text/html';
 
   /**
    * Creates an HTML document using `DOMParser.parseFromString`.
@@ -49,11 +43,6 @@ if (typeof window.DOMParser === 'function') {
   parseFromString = function (html, tagName) {
     if (tagName) {
       html = '<' + tagName + '>' + html + '</' + tagName + '>';
-    }
-
-    // because IE9 only supports MIME type 'text/xml', void elements need to be self-closed
-    if (isIE9) {
-      html = html.replace(VOID_ELEMENTS_REGEX, '<$1$2$3/>');
     }
 
     return domParser.parseFromString(html, mimeType);

--- a/lib/client/html-to-dom.js
+++ b/lib/client/html-to-dom.js
@@ -1,15 +1,12 @@
 var domparser = require('./domparser');
-var utilities = require('./utilities');
-
-var formatDOM = utilities.formatDOM;
-var isIE9 = utilities.isIE(9);
+var formatDOM = require('./utilities').formatDOM;
 
 var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
 
 /**
  * Parses HTML string to DOM nodes in browser.
  *
- * @param  {String} html  - HTML markup.
+ * @param  {string} html  - HTML markup.
  * @return {DomElement[]} - DOM elements.
  */
 function HTMLDOMParser(html) {
@@ -17,7 +14,7 @@ function HTMLDOMParser(html) {
     throw new TypeError('First argument must be a string');
   }
 
-  if (!html) {
+  if (html === '') {
     return [];
   }
 
@@ -27,12 +24,6 @@ function HTMLDOMParser(html) {
 
   if (match && match[1]) {
     directive = match[1];
-
-    // remove directive in IE9 because DOMParser uses
-    // MIME type 'text/xml' instead of 'text/html'
-    if (isIE9) {
-      html = html.replace(match[0], '');
-    }
   }
 
   return formatDOM(domparser(html), null, directive);

--- a/lib/client/utilities.d.ts
+++ b/lib/client/utilities.d.ts
@@ -29,7 +29,6 @@ export function formatDOM(
 /**
  * Detects if browser is Internet Explorer.
  *
- * @param  version - IE version to detect.
- * @return         - Whether IE or the version is detected.
+ * @return - Whether IE is detected.
  */
-export function isIE(version?: number): boolean;
+export function isIE(): boolean;

--- a/lib/client/utilities.js
+++ b/lib/client/utilities.js
@@ -132,13 +132,9 @@ function formatDOM(nodes, parent, directive) {
 /**
  * Detects if browser is Internet Explorer.
  *
- * @param  {number}  [version] - IE version to detect.
- * @return {boolean}           - Whether IE or the version is detected.
+ * @return {boolean} - Whether IE is detected.
  */
-function isIE(version) {
-  if (version) {
-    return document.documentMode === version;
-  }
+function isIE() {
   return /(MSIE |Trident\/|Edge\/)/.test(navigator.userAgent);
 }
 


### PR DESCRIPTION
## What is the motivation for this pull request?

perf(client): deprecate Internet Explorer 9 (IE9)

## What is the current behavior?

Client parser supported IE9.

## What is the new behavior?

Client parser no longer supports IE9 (deprecated).

## Checklist:

- [ ] Tests
- [x] Types
- [ ] Documentation
