### PR TITLE
test: add and update tests, cleanup `domparser` given IE9 deprecation

### DIFF
--- a/lib/client/domparser.js
+++ b/lib/client/domparser.js
@@ -1,5 +1,3 @@
-var utilities = require('./utilities');
-
 // constants
 var HTML = 'html';
 var HEAD = 'head';
@@ -7,9 +5,6 @@ var BODY = 'body';
 var FIRST_TAG_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
 var HEAD_TAG_REGEX = /<head.*>/i;
 var BODY_TAG_REGEX = /<body.*>/i;
-
-// detect Internet Explorer
-var isIE = utilities.isIE();
 
 // falls back to `parseFromString` if `createHTMLDocument` cannot be used
 var parseFromDocument = function () {
@@ -57,10 +52,12 @@ if (typeof window.DOMParser === 'function') {
  * @see https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument
  */
 if (document.implementation) {
+  var isIE = require('./utilities').isIE;
+
   // title parameter is required in IE
   // https://msdn.microsoft.com/en-us/library/ff975457(v=vs.85).aspx
   var doc = document.implementation.createHTMLDocument(
-    isIE ? 'html-dom-parser' : undefined
+    isIE() ? 'html-dom-parser' : undefined
   );
 
   /**
@@ -76,15 +73,8 @@ if (document.implementation) {
       return doc;
     }
 
-    try {
-      doc.documentElement.innerHTML = html;
-      return doc;
-      // fallback when certain elements in `documentElement` are read-only (IE9)
-    } catch (err) {
-      if (parseFromString) {
-        return parseFromString(html);
-      }
-    }
+    doc.documentElement.innerHTML = html;
+    return doc;
   };
 }
 

--- a/test/cases/html.js
+++ b/test/cases/html.js
@@ -67,6 +67,10 @@ module.exports = [
     data: '<title>text</title>'
   },
   {
+    name: 'title with text as tags',
+    data: '<title><b>text</b></title>'
+  },
+  {
     name: 'unclosed body',
     data: '<body>'
   },

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -7,6 +7,7 @@ var helpers = require('../helpers');
 describe('client parser', function () {
   helpers.throwErrors(assert, clientParser);
   helpers.runTests(assert, clientParser, serverParser, htmlCases);
+  helpers.testCaseSensitiveTags(assert, clientParser);
 
   describe('performance', function () {
     it('executes 1000 times in less than 50ms', function () {

--- a/test/client/utilities.js
+++ b/test/client/utilities.js
@@ -1,0 +1,12 @@
+var assert = window.chai.assert;
+var utilities = require('../../lib/client/utilities');
+
+describe('client utilities', function () {
+  describe('formatDOM', function () {
+    it('continues loop when nodeType is undefined', function () {
+      var actual = utilities.formatDOM([{ nodeType: undefined }]);
+      var expected = [];
+      assert.deepEqual(actual, expected);
+    });
+  });
+});

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   runTests: require('./run-tests'),
+  testCaseSensitiveTags: require('./test-case-sensitive-tags'),
   throwErrors: require('./throw-errors')
 };

--- a/test/helpers/test-case-sensitive-tags.js
+++ b/test/helpers/test-case-sensitive-tags.js
@@ -1,0 +1,17 @@
+var constants = require('../../lib/client/constants');
+
+/**
+ * Tests case-sensitive tags (SVG) to make sure their case is preserved.
+ *
+ * @param {Function} parser - The parser.
+ */
+function testCaseSensitiveTags(assert, parser) {
+  it('preserves case of case-sensitive SVG tags', function () {
+    constants.CASE_SENSITIVE_TAG_NAMES.forEach(function (tag) {
+      var parsed = parser('<' + tag + '></' + tag + '>');
+      assert.equal(parsed[0].name, tag);
+    });
+  });
+}
+
+module.exports = testCaseSensitiveTags;

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -1,22 +1,7 @@
 const { assert } = require('chai');
 const htmlparser = require('htmlparser2');
 const cases = require('../cases');
-const { runTests, throwErrors } = require('../helpers');
-const { CASE_SENSITIVE_TAG_NAMES } = require('../../lib/client/constants');
-
-/**
- * Tests case-sensitive tags (SVG) to make sure their case is preserved.
- *
- * @param {Function} parser - The parser.
- */
-function testCaseSensitiveTags(parser) {
-  it('preserves case of case-sensitive SVG tags', () => {
-    CASE_SENSITIVE_TAG_NAMES.forEach(tag => {
-      const parsed = parser(`<${tag}></${tag}>`);
-      assert.equal(parsed[0].name, tag);
-    });
-  });
-}
+const { runTests, testCaseSensitiveTags, throwErrors } = require('../helpers');
 
 describe('server parser', () => {
   // before
@@ -26,6 +11,8 @@ describe('server parser', () => {
   throwErrors(assert, serverParser);
   runTests(assert, serverParser, htmlparser.parseDOM, cases.html);
   runTests(assert, serverParser, htmlparser.parseDOM, cases.svg);
+  // TODO: case-sensitive (SVG) tags are not preserved in server parser
+  // testCaseSensitiveTags(assert, serverParser);
 });
 
 describe('client parser in jsdom', () => {
@@ -38,7 +25,7 @@ describe('client parser in jsdom', () => {
   throwErrors(assert, clientParser);
   runTests(assert, clientParser, htmlparser.parseDOM, cases.html);
   runTests(assert, clientParser, htmlparser.parseDOM, cases.svg);
-  testCaseSensitiveTags(clientParser);
+  testCaseSensitiveTags(assert, clientParser);
 
   // after
   jsdomify.destroy();


### PR DESCRIPTION
## What is the motivation for this pull request?

- test: add and update tests
- refactor: cleanup `domparser` given IE9 deprecation

## Checklist:

- [x] Tests
- [ ] Types
- [ ] Documentation
