### PR TITLE
perf: upgrade dependency htmlparser2 to v7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "domhandler": "4.2.2",
-    "htmlparser2": "6.1.0"
+    "htmlparser2": "7.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "15.0.0",


### PR DESCRIPTION
Closes #134

## What is the motivation for this pull request?

Upgrade `htmlparser2` to [7.2.0](https://github.com/fb55/htmlparser2/releases/tag/v7.2.0)

We shouldn't be affected by breaking changes in [7.0.0](https://github.com/fb55/htmlparser2/releases/tag/v7.0.0)

```
 htmlparser2  6.1.0  →  7.2.0
```