### PR TITLE
ci(github): set Node.js version to 14 in build.yml workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
 
       - name: Use Node.js
         uses: actions/setup-node@v2
+        with:
+          # http://karma-runner.github.io/6.3/intro/installation.html
+          node-version: 14
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
## What is the motivation for this pull request?

ci: set Node.js version to 14 in build.yml workflow

## What is the current behavior?

Karma failures in #172 and #174

## What is the new behavior?

Lock Node.js version since LTS is 16

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)