### PR TITLE
chore: upgrade devDeps and update TS version in declaration files

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-dom-parser.min.js",
-    "limit": "3 KB"
+    "limit": "3.13 KB"
   }
 ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 export { default } from './lib/server/html-to-dom';

--- a/lib/client/constants.d.ts
+++ b/lib/client/constants.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 /**
  * SVG elements, unlike HTML elements, are case-sensitive.

--- a/lib/client/domparser.d.ts
+++ b/lib/client/domparser.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 /**
  * Parses HTML string to DOM nodes.

--- a/lib/client/html-to-dom.d.ts
+++ b/lib/client/html-to-dom.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 import { DataNode, Element } from 'domhandler';
 

--- a/lib/client/utilities.d.ts
+++ b/lib/client/utilities.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 import { Comment, Element, ProcessingInstruction, Text } from 'domhandler';
 

--- a/lib/server/html-to-dom.d.ts
+++ b/lib/server/html-to-dom.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 import {
   Comment,

--- a/lib/server/utilities.d.ts
+++ b/lib/server/utilities.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.3
+// TypeScript Version: 4.7
 
 type Nodes = Array<Comment | Element | ProcessingInstruction | Text>;
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "@commitlint/config-conventional": "16.2.1",
     "@rollup/plugin-commonjs": "21.0.2",
     "@rollup/plugin-node-resolve": "13.1.3",
-    "@size-limit/preset-big-lib": "5.0.3",
+    "@size-limit/preset-big-lib": "7.0.8",
+    "@types/estree": "0.0.51",
     "chai": "4.3.6",
     "dtslint": "4.2.1",
     "eslint": "8.11.0",
@@ -74,9 +75,9 @@
     "rollup": "2.70.1",
     "rollup-plugin-terser": "7.0.2",
     "sinon": "13.0.1",
-    "size-limit": "5.0.3",
+    "size-limit": "7.0.8",
     "typescript": "4.6.2",
-    "webpack": "4.46.0",
+    "webpack": "5.70.0",
     "webpack-cli": "4.9.2"
   },
   "files": [


### PR DESCRIPTION
## What is the motivation for this pull request?

chore: upgrade devDeps and update TS version in declaration files

```
 @size-limit/preset-big-lib   5.0.3  →   7.0.8
 size-limit                   5.0.3  →   7.0.8
 webpack                     4.46.0  →  5.70.0
```

Saved devDependency `@types/estree` due to dtslint error that came from deduped deps and `@rollup/pluginutils@3.1.0`. See [blog post](https://remarkablemark.org/blog/2022/03/19/dtslint-error-estree-has-no-exported-member/)

Updated TypeScript Version from 4.3 to 4.7 in declaration files

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Types