### PR TITLE
test(types): fix dtslint errors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint:dts && npm test && npx lint-staged
+npm test
+npx lint-staged

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -1,16 +1,16 @@
 import parse from 'html-dom-parser';
 
-// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
+// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
 parse('<div>text</div>');
 
-// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
+// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
 parse('<div>text</div>', { normalizeWhitespace: true });
 
-// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
+// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
 parse('<div>text</div>', { withStartIndices: true });
 
-// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
+// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
 parse('<div>text</div>', { withEndIndices: true });
 
-// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
+// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
 parse('');


### PR DESCRIPTION
Relates to #236, #238, #239, #240

## What is the motivation for this pull request?

test(types): fix dtslint expect errors

Don't run `npm run lint:dts` in husky pre-commit hook

## What is the current behavior?

dtslint errors:

```
Error: /home/runner/work/html-dom-parser/html-dom-parser/test/types/index.test.ts:4:1
ERROR: 4:1   expect  TypeScript@4.7 expected type to be:
  (Comment | Element | ProcessingInstruction | Text)[]
got:
  (Text | Comment | ProcessingInstruction | Element)[]
```

## What is the new behavior?

No dtslint errors

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests