### PR TITLE
feat(client): remove Internet Explorer (IE11) support

### DIFF
--- a/lib/client/domparser.js
+++ b/lib/client/domparser.js
@@ -52,13 +52,7 @@ if (typeof window.DOMParser === 'function') {
  * @see https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument
  */
 if (document.implementation) {
-  var isIE = require('./utilities').isIE;
-
-  // title parameter is required in IE
-  // https://msdn.microsoft.com/en-us/library/ff975457(v=vs.85).aspx
-  var doc = document.implementation.createHTMLDocument(
-    isIE() ? 'html-dom-parser' : undefined
-  );
+  var doc = document.implementation.createHTMLDocument();
 
   /**
    * Use HTML document created by `document.implementation.createHTMLDocument`.

--- a/lib/client/utilities.d.ts
+++ b/lib/client/utilities.d.ts
@@ -25,10 +25,3 @@ export function formatDOM(
   parent?: Element | null,
   directive?: string
 ): Array<Comment | Element | ProcessingInstruction | Text>;
-
-/**
- * Detects if browser is Internet Explorer.
- *
- * @return - Whether IE is detected.
- */
-export function isIE(): boolean;

--- a/lib/client/utilities.js
+++ b/lib/client/utilities.js
@@ -129,17 +129,7 @@ function formatDOM(nodes, parent, directive) {
   return result;
 }
 
-/**
- * Detects if browser is Internet Explorer.
- *
- * @return {boolean} - Whether IE is detected.
- */
-function isIE() {
-  return /(MSIE |Trident\/|Edge\/)/.test(navigator.userAgent);
-}
-
 module.exports = {
   formatAttributes: formatAttributes,
-  formatDOM: formatDOM,
-  isIE: isIE
+  formatDOM: formatDOM
 };


### PR DESCRIPTION
## What is the motivation for this pull request?

BREAKING CHANGE: remove Internet Explorer (IE11) support

Internet Explorer has been retired on 2022-06-15: https://blogs.windows.com/windowsexperience/2022/06/15/internet-explorer-11-has-retired-and-is-officially-out-of-support-what-you-need-to-know/

Closes #225

## What is the current behavior?

IE11 still supported

## What is the new behavior?

IE11 is no longer supported

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Types