### PR TITLE
fix(client): ensure head and body with newline are parsed correctly

### DIFF
--- a/lib/client/domparser.js
+++ b/lib/client/domparser.js
@@ -3,8 +3,9 @@ var HTML = 'html';
 var HEAD = 'head';
 var BODY = 'body';
 var FIRST_TAG_REGEX = /<([a-zA-Z]+[0-9]?)/; // e.g., <h1>
-var HEAD_TAG_REGEX = /<head.*>/i;
-var BODY_TAG_REGEX = /<body.*>/i;
+// match-all-characters in case of newlines (DOTALL)
+var HEAD_TAG_REGEX = /<head[^]*>/i;
+var BODY_TAG_REGEX = /<body[^]*>/i;
 
 // falls back to `parseFromString` if `createHTMLDocument` cannot be used
 var parseFromDocument = function () {
@@ -63,7 +64,8 @@ if (document.implementation) {
    */
   parseFromDocument = function (html, tagName) {
     if (tagName) {
-      doc.documentElement.getElementsByTagName(tagName)[0].innerHTML = html;
+      var element = doc.documentElement.querySelector(tagName);
+      element.innerHTML = html;
       return doc;
     }
 
@@ -118,24 +120,25 @@ function domparser(html) {
       // the created document may come with filler head/body elements,
       // so make sure to remove them if they don't actually exist
       if (!HEAD_TAG_REGEX.test(html)) {
-        element = doc.getElementsByTagName(HEAD)[0];
+        element = doc.querySelector(HEAD);
         if (element) {
           element.parentNode.removeChild(element);
         }
       }
 
       if (!BODY_TAG_REGEX.test(html)) {
-        element = doc.getElementsByTagName(BODY)[0];
+        element = doc.querySelector(BODY);
         if (element) {
           element.parentNode.removeChild(element);
         }
       }
 
-      return doc.getElementsByTagName(HTML);
+      return doc.querySelectorAll(HTML);
 
     case HEAD:
     case BODY:
-      elements = parseFromDocument(html).getElementsByTagName(firstTagName);
+      doc = parseFromDocument(html);
+      elements = doc.querySelectorAll(firstTagName);
 
       // if there's a sibling element, then return both elements
       if (BODY_TAG_REGEX.test(html) && HEAD_TAG_REGEX.test(html)) {
@@ -148,9 +151,8 @@ function domparser(html) {
       if (parseFromTemplate) {
         return parseFromTemplate(html);
       }
-
-      return parseFromDocument(html, BODY).getElementsByTagName(BODY)[0]
-        .childNodes;
+      element = parseFromDocument(html, BODY).querySelector(BODY);
+      return element.childNodes;
   }
 }
 

--- a/test/cases/html.js
+++ b/test/cases/html.js
@@ -86,6 +86,18 @@ module.exports = [
     name: 'body with paragraph',
     data: '<body><p>text</p></body>'
   },
+  {
+    name: 'head and body with newline',
+    data: '<head></head><body\n>text</body>'
+  },
+  {
+    name: 'head and body with whitespace and newlines',
+    data: '<head><title>hello</title></head><body \n\n >text</body>'
+  },
+  {
+    name: 'body with whitespace and newline',
+    data: '<body \n >text</body>'
+  },
 
   // common tags
   {


### PR DESCRIPTION
Fixes #317

https://github.com/remarkablemark/html-react-parser/issues/624

## What is the motivation for this pull request?

fix(client): ensure head and body with newline are parsed correctly

## What is the current behavior?

`head` and `body` with newlines aren't matched correctly with the [regex](https://github.com/remarkablemark/html-dom-parser/blob/v3.0.0/lib/client/domparser.js#L6-L7)

## What is the new behavior?

`head` and `body` with newlines are matched correctly with the DOTALL regex

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests