### PR TITLE
fix(client): correct ECMAScript export in client html-to-dom.mjs

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-dom-parser.min.js",
-    "limit": "3.87 KB"
+    "limit": "3.89 KB"
   }
 ]

--- a/lib/client/domparser.js
+++ b/lib/client/domparser.js
@@ -20,13 +20,15 @@ var parseFromString = function () {
   );
 };
 
+var DOMParser = typeof window === 'object' && window.DOMParser;
+
 /**
  * DOMParser (performance: slow).
  *
  * @see https://developer.mozilla.org/docs/Web/API/DOMParser#Parsing_an_SVG_or_HTML_document
  */
-if (typeof window.DOMParser === 'function') {
-  var domParser = new window.DOMParser();
+if (typeof DOMParser === 'function') {
+  var domParser = new DOMParser();
   var mimeType = 'text/html';
 
   /**
@@ -52,7 +54,7 @@ if (typeof window.DOMParser === 'function') {
  *
  * @see https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument
  */
-if (document.implementation) {
+if (typeof document === 'object' && document.implementation) {
   var doc = document.implementation.createHTMLDocument();
 
   /**
@@ -79,7 +81,9 @@ if (document.implementation) {
  *
  * @see https://developer.mozilla.org/docs/Web/HTML/Element/template
  */
-var template = document.createElement('template');
+var template =
+  typeof document === 'object' ? document.createElement('template') : {};
+
 var parseFromTemplate;
 
 if (template.content) {

--- a/lib/client/html-to-dom.mjs
+++ b/lib/client/html-to-dom.mjs
@@ -1,5 +1,5 @@
-import domparser from './domparser';
-import { formatDOM } from './utilities';
+import domparser from './domparser.js';
+import { formatDOM } from './utilities.js';
 
 var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
 
@@ -29,5 +29,4 @@ function HTMLDOMParser(html) {
   return formatDOM(domparser(html), null, directive);
 }
 
-module.exports = HTMLDOMParser;
-module.exports.default = HTMLDOMParser;
+export default HTMLDOMParser;

--- a/test/module/index.mjs
+++ b/test/module/index.mjs
@@ -1,4 +1,6 @@
 import assert from 'assert';
 import HTMLDOMParser from '../../index.mjs';
+import HTMLDOMParserClient from '../../lib/client/html-to-dom.mjs';
 
 assert.strictEqual(typeof HTMLDOMParser, 'function');
+assert.strictEqual(typeof HTMLDOMParserClient, 'function');


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(client): correct ECMAScript export in client html-to-dom.mjs

Fixes #334

## What is the current behavior?

```
ReferenceError: module is not defined
```

## What is the new behavior?

No ReferenceError

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Types
- [ ] Documentation