### PR TITLE
fix(client): fix import in html-to-dom.mjs

### DIFF
--- a/lib/client/html-to-dom.js
+++ b/lib/client/html-to-dom.js
@@ -1,5 +1,7 @@
 var domparser = require('./domparser');
-var formatDOM = require('./utilities').formatDOM;
+var utilities = require('./utilities');
+
+var formatDOM = utilities.formatDOM;
 
 var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
 

--- a/lib/client/html-to-dom.mjs
+++ b/lib/client/html-to-dom.mjs
@@ -1,5 +1,7 @@
 import domparser from './domparser.js';
-import { formatDOM } from './utilities.js';
+import utilities from './utilities.js';
+
+var formatDOM = utilities.formatDOM;
 
 var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
 
@@ -9,7 +11,7 @@ var DIRECTIVE_REGEX = /<(![a-zA-Z\s]+)>/; // e.g., <!doctype html>
  * @param  {string} html  - HTML markup.
  * @return {DomElement[]} - DOM elements.
  */
-function HTMLDOMParser(html) {
+export default function HTMLDOMParser(html) {
   if (typeof html !== 'string') {
     throw new TypeError('First argument must be a string');
   }
@@ -28,5 +30,3 @@ function HTMLDOMParser(html) {
 
   return formatDOM(domparser(html), null, directive);
 }
-
-export default HTMLDOMParser;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(client): fix import in html-to-dom.mjs

Fixes #337

Relates to https://github.com/remarkablemark/html-react-parser/issues/662

## What is the current behavior?

Client error:

```
error - /app/node_modules/html-dom-parser/lib/client/html-to-dom.mjs
Can't import the named export 'formatDOM' from non EcmaScript module (only default export is available)
```

## What is the new behavior?

Fixes error

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Types
- [ ] Documentation