### PR TITLE
fix(package): specify types in package.json and exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "HTML to DOM parser.",
   "author": "Mark <mark@remarkablemark.org>",
   "main": "index.js",
+  "types": "index.d.ts",
   "module": "index.mjs",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./index.mjs",
     "require": "./index.js"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): specify types in package.json and exports field

Add support for native ESM with TypeScript in Node.js 16 mode

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Types
- [ ] Documentation