### PR TITLE
fix(client): get template content childNodes in utilities formatDOM

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-dom-parser.min.js",
-    "limit": "3.89 KB"
+    "limit": "3.894 KB"
   }
 ]

--- a/lib/client/utilities.js
+++ b/lib/client/utilities.js
@@ -83,7 +83,11 @@ function formatDOM(nodes, parent, directive) {
           formatTagName(node.nodeName),
           formatAttributes(node.attributes)
         );
-        current.children = formatDOM(node.childNodes, current);
+        current.children = formatDOM(
+          // template children are on content
+          node.content ? node.content.childNodes : node.childNodes,
+          current
+        );
         break;
 
       case 3:

--- a/test/cases/html.js
+++ b/test/cases/html.js
@@ -227,6 +227,16 @@ module.exports = [
     }
   },
 
+  // template tag
+  {
+    name: 'empty template',
+    data: '<template></template>'
+  },
+  {
+    name: 'template with content',
+    data: '<template><article><p>Test</p></article></template>'
+  },
+
   // style tag
   {
     name: 'empty style',


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes #414

Relates to https://github.com/remarkablemark/html-react-parser/issues/849

## What is the current behavior?

`<template>` childNodes is not parsed correctly

## What is the new behavior?

`<template>` childNodes are parsed correctly

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Types
- [ ] Documentation