### PR TITLE
fix(client): check for "template" in utilities formatDOM

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-dom-parser.min.js",
-    "limit": "3.894 KB"
+    "limit": "3.9 KB"
   }
 ]

--- a/lib/client/utilities.js
+++ b/lib/client/utilities.js
@@ -70,6 +70,7 @@ function formatTagName(tagName) {
 function formatDOM(nodes, parent, directive) {
   parent = parent || null;
   var result = [];
+  var tagName;
 
   for (var index = 0, len = nodes.length; index < len; index++) {
     var node = nodes[index];
@@ -78,14 +79,12 @@ function formatDOM(nodes, parent, directive) {
     // set the node data given the type
     switch (node.nodeType) {
       case 1:
+        tagName = formatTagName(node.nodeName);
         // script, style, or tag
-        current = new Element(
-          formatTagName(node.nodeName),
-          formatAttributes(node.attributes)
-        );
+        current = new Element(tagName, formatAttributes(node.attributes));
         current.children = formatDOM(
           // template children are on content
-          node.content ? node.content.childNodes : node.childNodes,
+          tagName === 'template' ? node.content.childNodes : node.childNodes,
           current
         );
         break;

--- a/test/cases/html.js
+++ b/test/cases/html.js
@@ -117,6 +117,10 @@ module.exports = [
     data: '<meta charset="utf-8">'
   },
   {
+    name: 'meta with closing tag',
+    data: '<meta name="author" content="John Doe Mason" />'
+  },
+  {
     name: 'textarea with value',
     data: '<textarea>value</textarea>'
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes #417

## What is the current behavior?

```
TypeError: Cannot read properties of undefined (reading 'length')
 at formatDOM (lib/client/utilities.js)
```

## What is the new behavior?

Error should no longer be thrown

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Types
- [ ] Documentation