### PR TITLE
build(deps): bump htmlparser2 from 8.0.2 to 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
-        "htmlparser2": "8.0.2"
+        "htmlparser2": "9.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "17.6.5",
@@ -4842,7 +4842,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4850,12 +4852,11 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-errors": {
@@ -13742,12 +13743,14 @@
       }
     },
     "htmlparser2": {
-      "version": "8.0.2",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "http-errors": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "htmlparser2": "8.0.2"
+    "htmlparser2": "9.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "17.6.5",


### PR DESCRIPTION
## What is the motivation for this pull request?

BREAKING CHANGE: bump htmlparser2 from 8.0.2 to 9.0.0

Closes #459

https://github.com/fb55/htmlparser2/releases/tag/v9.0.0

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Types
- [ ] Documentation