### PR TITLE
Remove unused dependencies declared in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "rollup": "2.79.1",
     "rollup-plugin-terser": "7.0.2",
     "sinon": "15.2.0",
-    "size-limit": "9.0.0",
     "typescript": "5.2.2"
   },
   "files": [


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

I noticed that the `size-limit` package declared in the package.json file is unused in the source files of the project. Removing unused dependencies has an impact on the number of CI build minutes that are consumed during CI due to bumpings of unused dependencies by bots. In fact, I noticed the commits, bumping versions of these unused dependencies made by the dependabot, and those commits consume a substantial amount of CI build time.
On the other hand, removing unused dependencies may reduce the number of pull requests needed to be reviewed by developers for such cases. Thus, I am creating this PR to remove those unused dependencies.
Thus, I am submitting this PR to suggest removing unused dependencies.

## What is the new behavior?

Does not incur developer effort or CI build minutes due to vision bumping of unused dependencies made by the dependabot.

<!--
Any other comments? Thank you for contributing!
-->


