### PR TITLE
fix(esm): fix ESM types by adding .mts declaration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build directory
 dist/
+esm/types.ts
 lib/
 
 # Logs

--- a/esm/client/html-to-dom.d.mts
+++ b/esm/client/html-to-dom.d.mts
@@ -1,0 +1,3 @@
+import type { DOMNode } from '../types';
+
+export default function HTMLDOMParser(html: string): DOMNode[];

--- a/esm/index.d.mts
+++ b/esm/index.d.mts
@@ -1,0 +1,2 @@
+export { default } from './server/html-to-dom.mjs';
+export type * from './types';

--- a/esm/server/html-to-dom.d.mts
+++ b/esm/server/html-to-dom.d.mts
@@ -1,0 +1,7 @@
+import type { ParserOptions } from 'htmlparser2';
+import type { DOMNode } from '../types';
+
+export default function HTMLDOMParser(
+  html: string,
+  options?: ParserOptions,
+): DOMNode[];

--- a/package.json
+++ b/package.json
@@ -5,27 +5,24 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "./lib/index.js",
   "module": "./esm/index.mjs",
-  "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
       "import": "./esm/index.mjs",
       "require": "./lib/index.js"
     },
     "./lib/client/*": {
-      "types": "./lib/client/*.d.ts",
       "import": "./esm/client/*.mjs",
       "require": "./lib/client/*.js"
     },
     "./lib/server/*": {
-      "types": "./lib/server/*.d.ts",
       "import": "./esm/server/*.mjs",
       "require": "./lib/server/*.js"
     }
   },
   "scripts": {
-    "build": "run-p build:*",
+    "build": "run-s build:*",
     "build:cjs": "tsc",
+    "build:esm": "awk '!/sourceMappingURL/' lib/types.d.ts > esm/types.ts",
     "build:umd": "rollup --config --failAfterWarnings",
     "clean": "rm -rf .nyc_output coverage dist lib",
     "lint": "eslint . --ignore-path .gitignore",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(esm): fix ESM types by adding .mts declaration files

## What is the current behavior?

ESM types are pointing to the CJS extension

## What is the new behavior?

Added MTS declaration files in ESM

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Types
- [ ] Documentation