### PR TITLE
Fix type re-export

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { Comment, Element, ProcessingInstruction, Text } from 'domhandler';
 
-export { Comment, Element, ProcessingInstruction, Text };
+export type { Comment, Element, ProcessingInstruction, Text };
 
 export type DOMNode = Comment | Element | ProcessingInstruction | Text;


### PR DESCRIPTION
## What is the motivation for this pull request?

When importing html-dom-parser 5.0.5 from Typescript with `verbatimModuleSyntax` enabled the build fails with:
```
node_modules/.pnpm/html-dom-parser@5.0.5/node_modules/html-dom-parser/esm/types.ts:2:10 - error TS1448: 'Comment' resolves to a type-only declaration and must be re-exported using a type-only re-export when 'verbatimModuleSyntax' is enabled.

2 export { Comment, Element, ProcessingInstruction, Text };
```

## What is the current behavior?

Typescript fails

## What is the new behavior?

Typescript accepts the input

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Types
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
