### PR TITLE
fix(esm): fix exported types

### DIFF
--- a/esm/index.d.mts
+++ b/esm/index.d.mts
@@ -1,2 +1,2 @@
 export { default } from './server/html-to-dom.mjs';
-export type * from './types';
+export type * from './types.ts';


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(esm): fix exported types

Relates to #669

## What is the current behavior?

Exported ESM types do not have extension

## What is the new behavior?

Exported ESM types have extension

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Types
- [ ] Documentation