### PR TITLE
fix: exports field includes package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "./lib/server/*": {
       "import": "./esm/server/*.mjs",
       "require": "./lib/server/*.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "run-s build:*",


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Many users have bundler issues with this package and the [html-react-parser](https://github.com/remarkablemark/html-react-parser) package that depends on it.  Sometimes it is necessary to change how packages are resolved—for example, to force loading the server version in certain environments.

However, resolving the server version is difficult when importing the package.json is disabled by the package.json exports field.  This patch enables code to import the package.json.

Beyond this bundling use case, I have found importing the package.json may be useful for reading versions, dependencies, and other metadata.

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?

An error is thrown if you try to import the package.json

## What is the new behavior?

Importing the package.json is allowed

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->

Thank you for reviewing!