### PR TITLE
fix: bundle ESM-only server deps into CJS build to avoid ERR_REQUIRE_ESM_RACE_CONDITION

### DIFF
--- a/__tests__/esm/esm-race.test.mjs
+++ b/__tests__/esm/esm-race.test.mjs
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/require-await */
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { describe, it } from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Tests that CJS require does not throw ERR_REQUIRE_ESM_RACE_CONDITION
+ * when concurrent with ESM import for Node.js >=24.
+ *
+ * @see https://github.com/remarkablemark/html-dom-parser/issues/1551
+ */
+describe('CJS require concurrent with ESM import', () => {
+  it('does not throw ERR_REQUIRE_ESM_RACE_CONDITION', async () => {
+    const results = await Promise.allSettled([
+      import('domhandler'),
+      (async () => require('html-dom-parser'))(),
+    ]);
+
+    const failures = results.filter((result) => result.status === 'rejected');
+
+    assert.strictEqual(
+      failures.length,
+      0,
+      failures.map((failure) => failure.reason.message).join('\n'),
+    );
+  });
+});

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -28,6 +28,17 @@ export default defineConfig([
     format: 'cjs',
     name: 'cjs',
     outDir: 'lib',
+    deps: {
+      alwaysBundle: [
+        'domhandler',
+        'htmlparser2',
+        'domelementtype',
+        'domutils',
+        'entities',
+        'dom-serializer',
+      ],
+      onlyBundle: false,
+    },
     outExtensions() {
       return {
         dts: '.d.ts',


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix. On Node.js 24+, requiring `html-dom-parser` while `domhandler` is concurrently being imported via ESM throws `ERR_REQUIRE_ESM_RACE_CONDITION`.

Fixes #1551

## What is the current behavior?

The CJS build externalizes `domhandler` and `htmlparser2` as top-level `require()` calls. When a consumer runs:

```js
Promise.allSettled([
  import('domhandler'),
  (async () => require('html-dom-parser'))(),
])
```

Node sees `domhandler` being both `require()`d and `import()`ed at the same time and throws `ERR_REQUIRE_ESM_RACE_CONDITION`.

## What is the new behavior?

The CJS build now bundles `domhandler`, `htmlparser2`, and their transitive ESM-only dependencies into `lib/node_modules/`. The generated CJS file no longer performs top-level `require("domhandler")` / `require("htmlparser2")`, so the race condition cannot occur.

Browser and ESM builds are unchanged because they use the client/server entry points defined in `package.json` `browser` and `exports`, which do not load the bundled CJS server modules.

A regression test is added in `__tests__/esm/esm-race.test.mjs`.

[plan.md](https://github.com/user-attachments/files/31040278/plan.md)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation
